### PR TITLE
Fix use-after-free in glue code for pthread_join

### DIFF
--- a/include/pte_osal.h
+++ b/include/pte_osal.h
@@ -8,7 +8,7 @@
 extern "C" {
 #endif
 
-typedef struct uk_thread* pte_osThreadHandle;
+typedef struct pte_thread_data *pte_osThreadHandle;
 typedef struct uk_semaphore *pte_osSemaphoreHandle;
 typedef struct uk_mutex *pte_osMutexHandle;
 


### PR DESCRIPTION
When `pthread_join` is called, we use `uk_thread_wait` to wait for the
thread to exit. However, this will also release the thread and the
metadata for the pthread in the glue code. `pthread_join` then calls
`pthread_detach`, which attempts another wait, accessing the freed
thread.

The commit changes `pte_osThreadHandle` to point to the
metadata in the glue code instead of the thread itself and prevents
the metadata from being released on exit of the uk thread. This way,
`pthread_detach` can detect that the thread has already been released.
Metadata is freed in `pte_osThreadDelete` (would have caused a double
free before the patch).