### PR TITLE
Fix cast to uk_thread

### DIFF
--- a/attributes.c
+++ b/attributes.c
@@ -28,6 +28,7 @@
 #endif
 #include <pthread.h>
 #include <implement.h>
+#include <pte_osal.h>
 
 
 /* TODO We currently do not support guards */
@@ -93,7 +94,7 @@ int pthread_getattr_np(pthread_t thread, pthread_attr_t *attr)
 	if (attr == NULL || *attr == NULL)
 		return EINVAL;
 
-	_uk_thread = tp->threadId;
+	_uk_thread = pte_threadhandle_to_ukthread(tp->threadId);
 	_attr = *attr;
 	_attr->stackaddr = _uk_thread->stack;
 	_attr->stacksize = __STACK_SIZE;
@@ -119,7 +120,7 @@ int pthread_setname_np(pthread_t thread, const char *name)
 	if (tp == NULL || tp->threadId == NULL)
 		return ENOENT;
 
-	_uk_thread = tp->threadId;
+	_uk_thread = pte_threadhandle_to_ukthread(tp->threadId);
 
 	len = strnlen(name, 16);
 	if (len > 15)
@@ -139,7 +140,7 @@ int pthread_getname_np(pthread_t thread, char *name, size_t len)
 	if (tp == NULL || tp->threadId == NULL)
 		return ENOENT;
 
-	_uk_thread = tp->threadId;
+	_uk_thread = pte_threadhandle_to_ukthread(tp->threadId);
 
 	_len = strlen(_uk_thread->name);
 	if (len < _len + 1)

--- a/include/pte_osal.h
+++ b/include/pte_osal.h
@@ -15,6 +15,9 @@ typedef struct uk_mutex *pte_osMutexHandle;
 #define OS_MAX_SIMUL_THREADS \
 	CONFIG_LIBPTHREAD_EMBEDDED_MAX_SIMUL_THREADS
 
+#define pte_threadhandle_to_ukthread(handle) \
+	((struct uk_thread *)(handle))
+
 #ifdef __cplusplus
 }
 #endif

--- a/pte_osal.c
+++ b/pte_osal.c
@@ -38,12 +38,12 @@
 
 
 typedef struct pte_thread_data {
+	/* Unikraft thread - must be first, see pte_threadhandle_to_ukthread */
+	struct uk_thread *uk_thread;
 	/* thread routine */
 	pte_osThreadEntryPoint entry_point;
 	/* thread routine arguments */
 	void *argv;
-	/* Unikraft thread */
-	struct uk_thread *uk_thread;
 	/* TLS */
 	void *tls;
 	/* Semaphore for triggering thread start */


### PR DESCRIPTION
The bug fix for the use-after-free in pthread_join required to
change pte_osThreadHandle to point to pte_thread_data instead
of uk_thread. This commit changes pte_thread_data so it can
be cast to a uk_thread pointer.