### PR TITLE
Make ftime return wall clock

### DIFF
--- a/pte_osal.c
+++ b/pte_osal.c
@@ -661,7 +661,7 @@ pte_osResult pte_osTlsFree(unsigned int index)
 
 int ftime(struct timeb *tb)
 {
-	__nsec now = ukplat_monotonic_clock();
+	__nsec now = ukplat_wall_clock();
 
 	if (tb) {
 		tb->time = ukarch_time_nsec_to_sec(now);


### PR DESCRIPTION
The problem was discussed [here](https://github.com/unikraft/unikraft/issues/361).

Return wall clock on calling `ftime`, since the
function is used in `pte_relmillisecs` to find
the time offset as milliseconds from the current
system time.

`pte_relmillisecs` returns timeout as milliseconds
from current system time, got by calling `ftime` [here](https://github.com/RWTH-OS/pthread-embedded/blob/hermit/pte_relmillisecs.c#L75).
`sem_timedwait` calculates the time offset using
`pte_relmillisecs` [here](https://github.com/RWTH-OS/pthread-embedded/blob/hermit/sem_timedwait.c#L165) and then waits in a loop.

Using monotonic time results in a wrong offset
when using `sem_timedwait` that makes the `abstime`
argument be interpreted as a relative offset to
the monotonic clock start, not as an absolute value
since epoch.

Signed-off-by: Stefan Jumarea <stefanjumarea02@gmail.com>