### PR TITLE
Fix incompatible pointer type warning by typecast

### DIFF
--- a/attributes.c
+++ b/attributes.c
@@ -93,7 +93,7 @@ int pthread_getattr_np(pthread_t thread, pthread_attr_t *attr)
 	if (attr == NULL || *attr == NULL)
 		return EINVAL;
 
-	_uk_thread = tp->threadId;
+	_uk_thread = (struct uk_thread *) tp->threadId;
 	_attr = *attr;
 	_attr->stackaddr = _uk_thread->stack;
 	_attr->stacksize = __STACK_SIZE;
@@ -119,7 +119,7 @@ int pthread_setname_np(pthread_t thread, const char *name)
 	if (tp == NULL || tp->threadId == NULL)
 		return ENOENT;
 
-	_uk_thread = tp->threadId;
+	_uk_thread = (struct uk_thread *) tp->threadId;
 
 	len = strnlen(name, 16);
 	if (len > 15)
@@ -139,7 +139,7 @@ int pthread_getname_np(pthread_t thread, char *name, size_t len)
 	if (tp == NULL || tp->threadId == NULL)
 		return ENOENT;
 
-	_uk_thread = tp->threadId;
+	_uk_thread = (struct uk_thread *) tp->threadId;
 
 	_len = strlen(_uk_thread->name);
 	if (len < _len + 1)


### PR DESCRIPTION
This PR is a part of work for Unikraft Lyon Hackathon.

When building app-nginx, the warning below occurred

/home/ubuntu/workdir/libs/lib-pthread-embedded/attributes.c: In function ‘pthread_setname_np’: /home/ubuntu/workdir/libs/lib-pthread-embedded/attributes.c:122:13: warning: assignment to ‘struct uk_thread *’ from incompatible pointer type ‘pte_osThreadHandle’ {aka ‘struct pte_thread_data *’} [-Wincompatible-pointer-types]

To fix it we add typecast expressions on the corresponding statements