### PR TITLE
remove warning due to bad casts

### DIFF
--- a/attributes.c
+++ b/attributes.c
@@ -93,7 +93,7 @@ int pthread_getattr_np(pthread_t thread, pthread_attr_t *attr)
 	if (attr == NULL || *attr == NULL)
 		return EINVAL;
 
-	_uk_thread = tp->threadId;
+	_uk_thread = (struct uk_thread *) tp->threadId;
 	_attr = *attr;
 	_attr->stackaddr = _uk_thread->stack;
 	_attr->stacksize = __STACK_SIZE;
@@ -119,7 +119,7 @@ int pthread_setname_np(pthread_t thread, const char *name)
 	if (tp == NULL || tp->threadId == NULL)
 		return ENOENT;
 
-	_uk_thread = tp->threadId;
+	_uk_thread = (struct uk_thread*) tp->threadId;
 
 	len = strnlen(name, 16);
 	if (len > 15)
@@ -139,7 +139,7 @@ int pthread_getname_np(pthread_t thread, char *name, size_t len)
 	if (tp == NULL || tp->threadId == NULL)
 		return ENOENT;
 
-	_uk_thread = tp->threadId;
+	_uk_thread =(struct uk_thread*) tp->threadId;
 
 	_len = strlen(_uk_thread->name);
 	if (len < _len + 1)


### PR DESCRIPTION
This PR is part of the Unikraft Lyon Hackathon.

This warning occured while building [app-sqlite](https://github.com/unikraft/app-sqlite) :

```
/home/ubuntu/challenges/sqlite-warnings/libs/lib-pthread-embedded/attributes.c: In function ‘pthread_getattr_np’:
/home/ubuntu/challenges/sqlite-warnings/libs/lib-pthread-embedded/attributes.c:96:13: warning: assignment to ‘struct uk_thread *’ from incompatible pointer type ‘pte_osThreadHandle’ {aka ‘struct pte_thread_data *’} [-Wincompatible-pointer-types]
   96 |  _uk_thread = tp->threadId;
      |             ^
/home/ubuntu/challenges/sqlite-warnings/libs/lib-pthread-embedded/attributes.c: In function ‘pthread_setname_np’:
/home/ubuntu/challenges/sqlite-warnings/libs/lib-pthread-embedded/attributes.c:122:13: warning: assignment to ‘struct uk_thread *’ from incompatible pointer type ‘pte_osThreadHandle’ {aka ‘struct pte_thread_data *’} [-Wincompatible-pointer-types]
  122 |  _uk_thread = tp->threadId;
      |             ^
/home/ubuntu/challenges/sqlite-warnings/libs/lib-pthread-embedded/attributes.c: In function ‘pthread_getname_np’:
/home/ubuntu/challenges/sqlite-warnings/libs/lib-pthread-embedded/attributes.c:142:13: warning: assignment to ‘struct uk_thread *’ from incompatible pointer type ‘pte_osThreadHandle’ {aka ‘struct pte_thread_data *’} [-Wincompatible-pointer-types]
  142 |  _uk_thread = tp->threadId;
```

You need to cast ```tp->thread```  in ```struct uk_thread *``` to allow the assignment.