### PR TITLE
Introduce Library.uk

### DIFF
--- a/Library.uk
+++ b/Library.uk
@@ -1,0 +1,5 @@
+name        := "pthread-embedded"
+description := "POSIX Threads for embedded systems (PTE)."
+gitrepo     := "https://github.com/RWTH-OS/pthread-embedded.git"
+license     := "LGPL-2.1"
+version     := 44b41d7 sha256:92160588d3734b6d3e394bd6d30c18c50ac765705c6cad0d7d114706d5881e8a https://github.com/RWTH-OS/pthread-embedded/archive/44b41d7.tar.gz


### PR DESCRIPTION
This new file represents the first step towards proper versioning support of external microlibrary in Unikraft.  The file itself acts as mechanism for holding metadata-only values about the microlibrary.  This metadata is designed to be compatible with GNU Make whilst simultaneously being human-readable and readable by programs that are not GNU Make (e.g. tools such as KraftKit).

An important feature of this file is the inclusion of microlibrary versions. In a later step, once relevant integrations have been made to Unikrat's core build system and to relevant tools such as KraftKit, the user will be able to see and select from different versions of the microlibrary.

In this initial commit, the relevant metadata is absorbed from both Makefile.uk, Config.uk, but also includes new information such as SPDX License identifier. 

